### PR TITLE
Allow onBeforeWrite to be triggered from any controller extending LeftAndMain

### DIFF
--- a/code/Extension/JSONTextExtension.php
+++ b/code/Extension/JSONTextExtension.php
@@ -47,6 +47,7 @@ namespace PhpTek\JSONText\Extension;
 use PhpTek\JSONText\Exception\JSONTextException;
 use PhpTek\JSONText\ORM\FieldType\JSONText;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
+use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\ORM\DataExtension;
@@ -82,7 +83,7 @@ class JSONTextExtension extends DataExtension
         $doUpdate = (
             count($postVars) &&
             !empty($fieldMap) &&
-            in_array(get_class($controller), [CMSPageEditController::class])
+            $controller instanceof LeftAndMain
         );
 
         if (!$doUpdate) {


### PR DESCRIPTION
Currently, JSONTextExtension::onBeforeWrite() requires that the current controller be CMSPageEditController. This restricts the use of this extension on any ModelAdmin controllers. 

This change just checks that the current controller is a subclass of LeftAndMain, which every controller in the CMS should be.