### PR TITLE
Added config variable to control if updateJSON needs to fail when missing variable

### DIFF
--- a/code/Extension/JSONTextExtension.php
+++ b/code/Extension/JSONTextExtension.php
@@ -55,7 +55,6 @@ use PhpTek\JSONText\ORM\FieldType\JSONText;
 
 class JSONTextExtension extends DataExtension
 {
-
     public function __construct()
     {
         // Helpful class applicability message
@@ -66,27 +65,27 @@ class JSONTextExtension extends DataExtension
 
         return parent::__construct();
     }
-    
+
     /**
      * Deal with userland declaration of a config static or a method for obtaining
      * an array of CMS input fields. Existence of a method takes precedence over
      * a config static.
-     * 
+     *
      * @return array
      * @throws JSONTextConfigException When no field-mapping config is found.
      */
     public function getJSONFields()
     {
         $owner = $this->getOwner();
-        
+
         if (ClassInfo::hasMethod($owner, 'jsonFieldMap')) {
             return $owner->jsonFieldMap();
         }
-        
+
         if (!$owner->config()->get('json_field_map')) {
             throw new JSONTextConfigException('No field map found.');
         }
-        
+
         return $owner->config()->get('json_field_map');
     }
 
@@ -135,6 +134,9 @@ class JSONTextExtension extends DataExtension
 
             foreach ($mappedFields as $fieldName) {
                 if (!isset($postVars[$fieldName])) {
+                    if (!$this->owner->config()->get('jsonTextExtensionFailOnMissingKey') || false) {
+                        continue;
+                    }
                     $msg = sprintf('%s doesn\'t exist in POST data.', $fieldName);
                     throw new JSONTextException($msg);
                 }

--- a/code/Extension/JSONTextExtension.php
+++ b/code/Extension/JSONTextExtension.php
@@ -134,9 +134,16 @@ class JSONTextExtension extends DataExtension
 
             foreach ($mappedFields as $fieldName) {
                 if (!isset($postVars[$fieldName])) {
-                    if (!$this->owner->config()->get('jsonTextExtensionFailOnMissingKey') || false) {
+                    if ($this->owner->config()->get('jsonTextExtensionFailOnMissingKey') !== null) {
+                        $failOnMissingKey = $this->owner->config()->get('jsonTextExtensionFailOnMissingKey');
+                    } else {
+                        $failOnMissingKey = true;
+                    }
+
+                    if (!$failOnMissingKey) {
                         continue;
                     }
+
                     $msg = sprintf('%s doesn\'t exist in POST data.', $fieldName);
                     throw new JSONTextException($msg);
                 }


### PR DESCRIPTION
After migrating `sheadawson/silverstripe-linkable` to `gorriecoe/silverstripe-linkfield` I've was unable to add an Link to the SiteConfig.
Got the following exception;
`VARIABLE doesn't exist in POST data.`.
This exception came out of the `JSONTextExtension` of this module.

Seems that when you use `gorriecoe/silverstripe-linkfield` in combination with `JSONTextExtension` on `SiteConfig`, when you save the link, the `onBeforeWrite` => `updateJSON` gets triggered.

Because the Linkfield-form you are submitting (in the context of SiteConfig) not containing the JSON data, the exception comes up.

Fixed this by adding an config variable where you can disable the exception to be thrown;
```
Silverstripe\SiteConfig\SiteConfig:
  jsonTextExtensionFailOnMissingKey: false
```

This change seems to make everything work again, so decided to open an PR
Because of the way I've implemented this, this can be added without breaking changes :smile: .